### PR TITLE
feat: [AI] 회의 참석자 검색 정확도 개선 및 이름 인식 로직 강화

### DIFF
--- a/chatbot/chatbotSearch/search.py
+++ b/chatbot/chatbotSearch/search.py
@@ -2245,16 +2245,19 @@ def search_tasks(user_query: str, user_id: int = 1, meeting_id: int = None, user
                     for josa in josas:
                         cleaned_query = cleaned_query.replace(josa, ' ')
                     
-                    # 한글 이름 추출 (2-4글자)
-                    # DB에서 실제 사용자 이름 목록 가져오기
                     cursor.execute("SELECT name FROM user")
                     all_user_names = [row['name'] for row in cursor.fetchall()]
-                    
-                    # 쿼리에서 실제 이름 찾기
+
+                    # 호칭 제거 (님, 씨 등)
+                    cleaned_query = re.sub(r'(님|씨)(?=[^가-힣]|$)', '', user_query)
+
+                    # 쿼리에서 실제 이름 찾기 (가장 긴 이름부터 매칭)
                     found_name = None
-                    for name in all_user_names:
-                        if name in user_query:
+                    all_user_names_sorted = sorted(all_user_names, key=len, reverse=True)
+                    for name in all_user_names_sorted:
+                        if name in cleaned_query:
                             found_name = name
+                            print(f"[DEBUG] 이름 매칭 성공: '{name}' (원본: {user_query})")
                             break
                 
                 if not found_name:
@@ -2395,8 +2398,8 @@ def search_participants(query_type: str, meeting_id: int = None, person_name: st
                 user = cursor.fetchone()
                 
                 if not user:
-                    return (f"{person_name}님을 찾을 수 없어요. 😢", [])
-                
+                    return (f"{person_name}을(를) 찾을 수 없어요. 😢", [])
+
                 # 참석한 회의 목록 조회
                 cursor.execute("""
                     SELECT 


### PR DESCRIPTION
### 📋 요약
참석자 이름 추출 및 검색 로직을 개선하여 **"김철수님", "홍길동 씨"** 같은 호칭 포함 질문의 정확도를 향상시켰습니다.

---

### 🔧 주요 변경사항

#### **1️⃣ 이름 추출 로직 개선** (`chatbotSearchMain.py`)

**✅ 의문사 체크 로직 추가**
- "누가", "누구" 등 질문은 이름 추출 시도 안 함
- 불필요한 오인식 방지

**✅ 호칭 패턴 추가**
```python
r'([가-힣]{2,4})\s*(?:씨|님)'  # "김철수님", "홍길동 씨" 인식
```

**✅ 조사/호칭 제거 정규식 확장**
```python
# 기존: r'[가이은는을를]$'
# 변경: r'[가이은는을를님씨]$'
```

**✅ 불용어 확장**
- 추가: '누님', '그분', '저분', '이분'
- 일반 명사와 사람 이름 구분 강화

---

#### **2️⃣ 참석자 검색 알고리즘 최적화** (`search.py`)

**✅ DB 기반 실제 이름 매칭**
```python
cursor.execute("SELECT name FROM user")
all_user_names = [row['name'] for row in cursor.fetchall()]
```

**✅ 가장 긴 이름부터 우선 매칭**
```python
all_user_names_sorted = sorted(all_user_names, key=len, reverse=True)
```
→ "김철수", "김철" 둘 다 있을 때 "김철수" 우선

**✅ 호칭 제거 로직 통일**
```python
cleaned_query = re.sub(r'(님|씨)(?=[^가-힣]|$)', '', user_query)
```

**✅ 에러 메시지 개선**
```python
# 기존: f"{person_name}님을 찾을 수 없어요."
# 변경: f"{person_name}을(를) 찾을 수 없어요."
```